### PR TITLE
Added use_arc flag to draw_u function

### DIFF
--- a/launch/inf.launch
+++ b/launch/inf.launch
@@ -3,7 +3,7 @@
 <launch>
 
   <arg name="velocity" default="0.5" />
-  <arg name="use_arc" default="false" />
+  <arg name="use_arc" default="true" />
 
   <node pkg="turtlesim" type="turtlesim_node" name="turtlesim" output="screen" />
 

--- a/src/inf_main.cpp
+++ b/src/inf_main.cpp
@@ -2,7 +2,7 @@
 
 std::shared_ptr<tutorial::AbstractTurtle> turtle;
 
-void draw_u( bool cw ) {
+void draw_u( bool cw, bool use_arc ) {
     int sign;
     if ( cw ) {
         sign = -1;
@@ -11,11 +11,16 @@ void draw_u( bool cw ) {
     }
 
     turtle->turn( sign * 45 );
-    for (int i = 0; i < 3; i++) {
-        turtle->forward(3);
-        turtle->turn( sign * 90 );
+    if(use_arc){
+        turtle->arc( sign * 1.5, 180);
+        turtle->turn( sign * 45 );
+    }else {
+        for (int i = 0; i < 3; i++) {
+            turtle->forward(3);
+            turtle->turn( sign * 90 );
+        }
+        turtle->turn( sign * -45 );
     }
-    turtle->turn( sign * -45 );
 }
 
 int main(int argc, char **argv)
@@ -32,9 +37,9 @@ int main(int argc, char **argv)
     turtle->turn(45);
 
     turtle->forward( sqrt(4.5) );
-    draw_u( true );
+    draw_u( true, use_arc );
     turtle->forward( 2 * sqrt(4.5) );
-    draw_u( false );
+    draw_u( false, use_arc );
     turtle->forward( sqrt(4.5) );
 
     turtle.reset();


### PR DESCRIPTION
use_arc flag was not used in the draw_u function. It has been added. How the 'u' is drawn now depends on the use_arc flag.